### PR TITLE
Add cloud role for App Insights

### DIFF
--- a/helm/ea-wq-incident-web/templates/config-map.yaml
+++ b/helm/ea-wq-incident-web/templates/config-map.yaml
@@ -3,6 +3,7 @@
 data:
   NODE_ENV: {{ quote .Values.environment }}
   PORT: {{ quote .Values.container.port }}
+  APPINSIGHTS_CLOUDROLE: {{ quote .Values.name}}
   STATIC_CACHE_TIMEOUT_IN_MILLIS: {{ quote .Values.container.staticCacheTimeoutInMillis }}
   EMAIL_TO_ADDRESS: {{ quote .Values.container.emailToAddress }}
   NOTIFY_TEMPLATE_ID: {{ quote .Values.container.notifyTemplateId }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ea-incident-form-web",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "description-of-project-goes-here",
   "homepage": "https://github.com/DEFRA/ffc-template-node",
   "main": "app/index.js",


### PR DESCRIPTION
To enable reporting in App Insights the cloud roles must be set to the service name